### PR TITLE
Update and rename hotfx-split-flap.js to hotfx-split-flap-nums.js

### DIFF
--- a/hotfx-split-flap/hotfx-split-flap-nums.js
+++ b/hotfx-split-flap/hotfx-split-flap-nums.js
@@ -191,7 +191,7 @@ export class HotFXSplitFlap extends HTMLElement {
   // Here we're just pulling from the attribute which has the current value or
   // using the default Latin alphabet.
   get characters() {
-    return this.getAttribute('characters') || ' ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!.,:?"\'/$'
+    return this.getAttribute('characters') || ' 0123456789!.,:?"\'/$'
   }
 
   // Setter for `.characters` property that reflects to the attribute.

--- a/hotfx-split-flap/package.json
+++ b/hotfx-split-flap/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@hot-page/hotfx-split-flap",
-  "version": "0.0.1",
+  "name": "@kevinxmccormick/hotfx-split-flap-nums",
+  "version": "0.0.2",
   "description": "A custom HTML element that animates a string like split-flap board from a train station.",
   "main": "hotfx-split-flap.js",
   "type": "module",
@@ -9,9 +9,9 @@
     "custom-elements",
     "split flap"
   ],
-  "author": "Hot Page <info@hot.page>",
+  "author": "Kevin McCormick / Hot Page <info@hot.page>",
   "license": "MIT",
   "files": [
-    "hotfx-split-flap.js"
+    "hotfx-split-flap-nums.js"
   ]
 }

--- a/hotfx-split-flap/package.json
+++ b/hotfx-split-flap/package.json
@@ -2,7 +2,7 @@
   "name": "@kevinxmccormick/hotfx-split-flap-nums",
   "version": "0.0.2",
   "description": "A custom HTML element that animates a string like split-flap board from a train station.",
-  "main": "hotfx-split-flap.js",
+  "main": "hotfx-split-flap-nums.js",
   "type": "module",
   "keywords": [
     "web-components",


### PR DESCRIPTION
letters removed - for faster use in numerical only areas e.g. time.